### PR TITLE
Change offer help for a specific life form

### DIFF
--- a/apps/contacts/forms.py
+++ b/apps/contacts/forms.py
@@ -30,7 +30,7 @@ class ContactForm(forms.ModelForm):
     def __init__(self, *args, **kwargs):
         super(ContactForm, self).__init__(*args, **kwargs)
         self.fields['is_agreed'].required = True
-        self.fields['is_agreed'].widget.attrs['class'] = 'contact-form__is-agreed'
+        self.fields['is_agreed'].widget.attrs['class'] = 'is-agreed_spaced'
 
     def clean(self):
         cleaned_data = super(ContactForm, self).clean()

--- a/apps/contacts/forms.py
+++ b/apps/contacts/forms.py
@@ -51,9 +51,17 @@ class SchoolContactForm(forms.ModelForm):
             'position': 'Your position',
             'telephone': 'Your telephone',
             'email': 'Your email',
-            'workshop_date': 'Preferred workshop date',
+            'workshop_date': """Please enter 3 preferred dates for your workshop (we will do our
+                                best to accommodate one of the dates)""",
             'hear_about': 'How did you hear about us?',
         }
+
+    def __init__(self, *args, **kwargs):
+        super(SchoolContactForm, self).__init__(*args, **kwargs)
+        self.fields['is_agreed'].required = True
+        self.fields['is_agreed'].widget.attrs['class'] = 'is-agreed_spaced'
+        self.fields['workshop_date'].widget.attrs['rows'] = 3
+        self.fields['workshop_date'].widget.attrs['style'] = 'resize: none'
 
     def clean(self):
         cleaned_data = super(SchoolContactForm, self).clean()

--- a/apps/contacts/migrations/0005_change_is_agreed_text.py
+++ b/apps/contacts/migrations/0005_change_is_agreed_text.py
@@ -1,0 +1,19 @@
+# -*- coding: utf-8 -*-
+from __future__ import unicode_literals
+
+from django.db import migrations, models
+
+
+class Migration(migrations.Migration):
+
+    dependencies = [
+        ('contacts', '0004_add_is_agreed_to_contact'),
+    ]
+
+    operations = [
+        migrations.AlterField(
+            model_name='contact',
+            name='is_agreed',
+            field=models.BooleanField(default=False, help_text=b'Before submitting this form, please\n           <a href="/privacy/">click here to read our privacy policy</a>\n           and tick this box to confirm that you have read the policy notice and consent to the \n           processing of your personal data and sensitive personal data.'),
+        ),
+    ]

--- a/apps/contacts/migrations/0006_add_is_agreed_to_school_contact_and_change_workshop_date.py
+++ b/apps/contacts/migrations/0006_add_is_agreed_to_school_contact_and_change_workshop_date.py
@@ -1,0 +1,24 @@
+# -*- coding: utf-8 -*-
+from __future__ import unicode_literals
+
+from django.db import migrations, models
+
+
+class Migration(migrations.Migration):
+
+    dependencies = [
+        ('contacts', '0005_change_is_agreed_text'),
+    ]
+
+    operations = [
+        migrations.AddField(
+            model_name='schoolcontact',
+            name='is_agreed',
+            field=models.BooleanField(default=False, help_text=b'Before submitting this form, please\n           <a href="/privacy/">click here to read our privacy policy</a>\n           and tick this box to confirm that you have read the policy notice and consent to the \n           processing of your personal data and sensitive personal data.'),
+        ),
+        migrations.AlterField(
+            model_name='schoolcontact',
+            name='workshop_date',
+            field=models.TextField(blank=True),
+        ),
+    ]

--- a/apps/contacts/models.py
+++ b/apps/contacts/models.py
@@ -33,13 +33,14 @@ class SchoolContact(models.Model):
     school = models.CharField(max_length=150)
     position = models.CharField(max_length=120, blank=True)
     year_group = models.CharField(max_length=30, blank=True)
-    workshop_date = models.CharField(max_length=100, blank=True)
+    workshop_date = models.TextField(blank=True)
     address = models.TextField(blank=True)
     telephone = models.CharField(max_length=30, blank=True)
     email = models.EmailField(max_length=70)
     confirm_email = models.EmailField(max_length=70)
     hear_about = models.CharField(max_length=100, blank=True)
     created_at = models.DateTimeField(auto_now_add=True)
+    is_agreed = models.BooleanField(default=False, help_text=CONTACT_HELP_TEXTS['is_agreed'])
 
     def __str__(self):
         return u'{0} {1}'.format(self.name, self.email)

--- a/apps/people/forms.py
+++ b/apps/people/forms.py
@@ -6,6 +6,7 @@ from django.core.exceptions import ValidationError
 
 from . import choices as persons_choices
 from .models import Person, Nominee
+from .help_texts import PERSON_HELP_TEXTS
 
 
 class NominateForm(forms.ModelForm):
@@ -33,6 +34,7 @@ class NominateForm(forms.ModelForm):
         self.fields['reason'].widget = forms.widgets.HiddenInput()
         self.fields['reason'].initial = persons_choices.REASON_TYPE_WOULD_LIKE_TO_NOMINATE
         self.fields['is_agreed'].required = True
+        self.fields['is_agreed'].help_text = PERSON_HELP_TEXTS['is_agreed_nominator']
 
     
     def clean(self):

--- a/apps/people/forms.py
+++ b/apps/people/forms.py
@@ -94,6 +94,7 @@ class SupportForm(forms.ModelForm):
     def __init__(self, *args, **kwargs):
         super(SupportForm, self).__init__(*args, **kwargs)
         self.fields['is_agreed'].required = True
+        self.fields['is_agreed'].widget.attrs['class'] = 'is-agreed_spaced'
         self.fields['reason'].widget = forms.widgets.HiddenInput()
         self.fields['reason'].initial = persons_choices.REASON_TYPE_I_CAN_HELP
     

--- a/apps/people/forms.py
+++ b/apps/people/forms.py
@@ -72,11 +72,35 @@ NominatorFormSet = inlineformset_factory(
 
 
 class SupportForm(forms.ModelForm):
+    confirm_email = forms.EmailField(label='Re-enter email address:', required=False)
+
     class Meta:
         model = Person
-        exclude = ('created_at', 'updated_at', 'life',)
+        fields = (
+            'title',
+            'first_name',
+            'last_name',
+            'email',
+            'confirm_email',
+            'home_phone',
+            'message',
+            'hear_about_us',
+            'is_agreed',
+            'reason'
+        )
 
     def __init__(self, *args, **kwargs):
         super(SupportForm, self).__init__(*args, **kwargs)
         self.fields['reason'].widget = forms.widgets.HiddenInput()
         self.fields['reason'].initial = persons_choices.REASON_TYPE_I_CAN_HELP
+    
+    def clean(self):
+        cleaned_data = super(SupportForm, self).clean()
+
+        email = cleaned_data.get('email')
+        email_confirm = cleaned_data.get('confirm_email')
+
+        # Email isn't required here, so we only require confirmation if either
+        # of the e-mail fields is not empty
+        if (email or email_confirm) and email != email_confirm:
+            raise ValidationError({'confirm_email': ['The email addresses you entered do not match']})

--- a/apps/people/forms.py
+++ b/apps/people/forms.py
@@ -93,6 +93,7 @@ class SupportForm(forms.ModelForm):
 
     def __init__(self, *args, **kwargs):
         super(SupportForm, self).__init__(*args, **kwargs)
+        self.fields['is_agreed'].required = True
         self.fields['reason'].widget = forms.widgets.HiddenInput()
         self.fields['reason'].initial = persons_choices.REASON_TYPE_I_CAN_HELP
     

--- a/apps/people/help_texts.py
+++ b/apps/people/help_texts.py
@@ -3,12 +3,16 @@ from django.utils.safestring import mark_safe
 
 
 PERSON_HELP_TEXTS = {
+    'is_agreed_nominator': mark_safe(
+        """Before submitting your nomination, please 
+           <a href="https://52lives.contentfiles.net/media/assets/file/Final_Privacy_Notice_Nominator_Q0KzKUJ.pdf">click here to read our privacy notice</a> 
+           and tick this box to confirm that you have read the policy notice and consent to the 
+           processing of your personal data and sensitive personal data."""
+    ),
     'is_agreed': mark_safe(
-        'Before submitting your nomination, please '
-        '<a href="https://52lives.contentfiles.net/media/assets/file/Final_Privacy_Notice_Nominator_Q0KzKUJ.pdf">'
-        'click here to read our privacy notice'
-        '</a> '
-        'and tick this box to confirm that you have read the policy notice and consent to the '
-        'processing of your personal data and sensitive personal data.'
+        """Before submitting this form, please
+           <a href="/privacy/">click here to read our privacy policy</a>
+           and tick this box to confirm that you have read the policy notice and consent to the 
+           processing of your personal data and sensitive personal data."""
     )
 }

--- a/apps/people/migrations/0011_change_is_agreed_text.py
+++ b/apps/people/migrations/0011_change_is_agreed_text.py
@@ -1,0 +1,19 @@
+# -*- coding: utf-8 -*-
+from __future__ import unicode_literals
+
+from django.db import migrations, models
+
+
+class Migration(migrations.Migration):
+
+    dependencies = [
+        ('people', '0010_simplify_nomination_form'),
+    ]
+
+    operations = [
+        migrations.AlterField(
+            model_name='person',
+            name='is_agreed',
+            field=models.BooleanField(default=False, help_text=b'Before submitting this form, please\n           <a href="/privacy/">click here to read our privacy policy</a>\n           and tick this box to confirm that you have read the policy notice and consent to the \n           processing of your personal data and sensitive personal data.'),
+        ),
+    ]

--- a/static/less/styles.less
+++ b/static/less/styles.less
@@ -844,11 +844,11 @@ h1 {
         font-family: .font;
     }
 
-    .contact-form__is-agreed + span {
+    #id_is_agreed.is-agreed_spaced + span {
         margin-bottom: 1.2rem;
     }
 
-    .contact-form__is-agreed + .helptext {
+    #id_is_agreed + .helptext {
         a:hover {
             color: white;
         }

--- a/static/less/styles.less
+++ b/static/less/styles.less
@@ -853,6 +853,10 @@ h1 {
             color: white;
         }
     }
+
+    .submit-button_wide {
+        width: 280px;
+    }
 }
 
 .support_formblock {

--- a/templates/lives/life_detail.html
+++ b/templates/lives/life_detail.html
@@ -42,7 +42,11 @@
             {% if not life.summary %}
                 <div style="text-align: center" class="form-callout">
                     <h1 class="title">Offer support</h1>
-                    <h2>Can you help? Please let us know.</h2>
+                    <h2>Offer help or send a message</h2>
+                    <p>
+                        (if you are sending a message of support for the person we’re helping, there
+                        is no need to fill in your email address or telephone number)<br><br>
+                    </p>
                 </div>
                 {% csrf_token %}
                 {{ form.as_p }}

--- a/templates/lives/life_detail.html
+++ b/templates/lives/life_detail.html
@@ -50,7 +50,7 @@
                 </div>
                 {% csrf_token %}
                 {{ form.as_p }}
-                <button type="submit">I can help</button>
+                <button type="submit" class="submit-button_wide">Send message</button>
             {% endif %}
         </form>
     </div>


### PR DESCRIPTION
This is a continuation of changes to 52 Lives (see #43 and #42  for very similar PRs), outlined here: https://developersociety.slack.com/files/U024G0M2L/FEPHT7R0T/Changes_to_Website_-_GDPR

Card here (with more specific instructions as subcards in the backlog): https://favro.com/organization/b03d6d6d9b11b61167ac4246/30e671746b81b504ef983ee8?card=Dev-8546

This particular PR changes the form on the pages for the specific lives, e.g.: https://www.52-lives.org/lives/190/, changing the help text for the privacy agreement checkbox, adding an e-mail confirmation field and validation for it, adding some spacing between the longer checkbox text and the form submission button.