### PR TITLE
Change school contact form

### DIFF
--- a/apps/contacts/forms.py
+++ b/apps/contacts/forms.py
@@ -61,6 +61,7 @@ class SchoolContactForm(forms.ModelForm):
         self.fields['is_agreed'].required = True
         self.fields['is_agreed'].widget.attrs['class'] = 'is-agreed_spaced'
         self.fields['workshop_date'].widget.attrs['rows'] = 3
+        self.fields['workshop_date'].widget.attrs['style'] = 'resize: none'
 
     def clean(self):
         cleaned_data = super(SchoolContactForm, self).clean()

--- a/apps/contacts/forms.py
+++ b/apps/contacts/forms.py
@@ -55,6 +55,11 @@ class SchoolContactForm(forms.ModelForm):
             'hear_about': 'How did you hear about us?',
         }
 
+    def __init__(self, *args, **kwargs):
+        super(SchoolContactForm, self).__init__(*args, **kwargs)
+        self.fields['is_agreed'].required = True
+        self.fields['is_agreed'].widget.attrs['class'] = 'is-agreed_spaced'
+
     def clean(self):
         cleaned_data = super(SchoolContactForm, self).clean()
         email = cleaned_data.get('email')

--- a/apps/contacts/forms.py
+++ b/apps/contacts/forms.py
@@ -51,7 +51,8 @@ class SchoolContactForm(forms.ModelForm):
             'position': 'Your position',
             'telephone': 'Your telephone',
             'email': 'Your email',
-            'workshop_date': 'Preferred workshop date',
+            'workshop_date': """Please enter 3 preferred dates for your workshop (we will do our
+                                best to accommodate one of the dates)""",
             'hear_about': 'How did you hear about us?',
         }
 
@@ -59,6 +60,7 @@ class SchoolContactForm(forms.ModelForm):
         super(SchoolContactForm, self).__init__(*args, **kwargs)
         self.fields['is_agreed'].required = True
         self.fields['is_agreed'].widget.attrs['class'] = 'is-agreed_spaced'
+        self.fields['workshop_date'].widget.attrs['rows'] = 3
 
     def clean(self):
         cleaned_data = super(SchoolContactForm, self).clean()

--- a/apps/contacts/migrations/0006_add_is_agreed_to_school_contact_and_change_workshop_date.py
+++ b/apps/contacts/migrations/0006_add_is_agreed_to_school_contact_and_change_workshop_date.py
@@ -1,0 +1,24 @@
+# -*- coding: utf-8 -*-
+from __future__ import unicode_literals
+
+from django.db import migrations, models
+
+
+class Migration(migrations.Migration):
+
+    dependencies = [
+        ('contacts', '0005_change_is_agreed_text'),
+    ]
+
+    operations = [
+        migrations.AddField(
+            model_name='schoolcontact',
+            name='is_agreed',
+            field=models.BooleanField(default=False, help_text=b'Before submitting this form, please\n           <a href="/privacy/">click here to read our privacy policy</a>\n           and tick this box to confirm that you have read the policy notice and consent to the \n           processing of your personal data and sensitive personal data.'),
+        ),
+        migrations.AlterField(
+            model_name='schoolcontact',
+            name='workshop_date',
+            field=models.TextField(blank=True),
+        ),
+    ]

--- a/apps/contacts/models.py
+++ b/apps/contacts/models.py
@@ -40,6 +40,7 @@ class SchoolContact(models.Model):
     confirm_email = models.EmailField(max_length=70)
     hear_about = models.CharField(max_length=100, blank=True)
     created_at = models.DateTimeField(auto_now_add=True)
+    is_agreed = models.BooleanField(default=False, help_text=CONTACT_HELP_TEXTS['is_agreed'])
 
     def __str__(self):
         return u'{0} {1}'.format(self.name, self.email)

--- a/apps/contacts/models.py
+++ b/apps/contacts/models.py
@@ -33,7 +33,7 @@ class SchoolContact(models.Model):
     school = models.CharField(max_length=150)
     position = models.CharField(max_length=120, blank=True)
     year_group = models.CharField(max_length=30, blank=True)
-    workshop_date = models.CharField(max_length=100, blank=True)
+    workshop_date = models.TextField(blank=True)
     address = models.TextField(blank=True)
     telephone = models.CharField(max_length=30, blank=True)
     email = models.EmailField(max_length=70)


### PR DESCRIPTION
This is a continuation of changes to 52 Lives (see #45 #43 and #42  for very similar PRs), outlined here: https://developersociety.slack.com/files/U024G0M2L/FEPHT7R0T/Changes_to_Website_-_GDPR

**Note this is branched off of #46** as I wanted to make use of some of the styles and tiny refactorings implemented there.

Card here (with more specific instructions as subcards in the backlog): https://favro.com/organization/b03d6d6d9b11b61167ac4246/30e671746b81b504ef983ee8?card=Dev-8552

This particular PR changes the contact form for schools: https://www.52-lives.org/schools/ adding a privacy agreement checkbox and space for entering 3 workshop dates rather than just one, changing the help text and the type of field.