### PR TITLE
Add cookie consent banner

### DIFF
--- a/static/js/cookies.js
+++ b/static/js/cookies.js
@@ -1,0 +1,35 @@
+var cookie_accept = document.querySelector('.cookie-notice__button_yes'),
+    cookie_decline = document.querySelector('.cookie-notice__button_no');
+
+// this cookie is used to determine if other cookies are saved
+if (cookie_accept) {
+    cookie_accept.addEventListener('click', function(e) {
+        var date_plus_one_year = new Date(
+            new Date().getTime() + 365 * 24 * 60 * 60 * 1000
+        ).toGMTString();
+
+        document.cookie =
+            'cookies_accepted=true' +
+            ';' +
+            'expires=' +
+            date_plus_one_year +
+            ';path=/';
+        location.reload();
+    });
+}
+
+if (cookie_decline) {
+    cookie_decline.addEventListener('click', function(e) {
+        var date_plus_one_year = new Date(
+            new Date().getTime() + 365 * 24 * 60 * 60 * 1000
+        ).toGMTString();
+
+        document.cookie =
+            'cookies_accepted=false' +
+            ';' +
+            'expires=' +
+            date_plus_one_year +
+            ';path=/';
+        location.reload();
+    });
+}

--- a/static/less/styles.less
+++ b/static/less/styles.less
@@ -1203,7 +1203,7 @@ h1 {
 
         @media all and (max-width: @breakpoint-mobile) {
             width: 100%;
-            height: 7rem;
+            height: 8rem;
             bottom: 0;
             left: 0;
             padding: 1rem;

--- a/static/less/styles.less
+++ b/static/less/styles.less
@@ -1140,6 +1140,100 @@ h1 {
             }
         }
     }
+
+    .cookie-consent {
+        .ribbon;
+        display: flex;
+        position: fixed;
+        height: 100px;
+        width: 80%;
+        bottom: 40px;
+        left: 10%;
+        margin: auto;
+        padding: 0;
+        z-index: 9999;
+
+        &:hover {
+            color: white;
+        }
+
+        .cookie-consent__text {
+            width: 60%;
+            margin: auto;
+
+            background-color: @green;
+            color: @purple;
+            font-size: 1.25rem;
+            font-weight: 300;
+            line-height: 1.5;
+        }
+
+        .cookie-consent__more-info {
+            display: inline;
+
+            &:hover {
+                color: @purple;
+            }
+        }
+
+        .cookie-consent__button-container {
+            margin: auto;
+        }
+
+        .cookie-consent__button {
+            margin-left: 0.5rem;
+            margin-right: 0.5rem;
+            border: none;
+            background-color: transparent;
+
+            &:hover {
+                color: @purple;
+            }
+        }
+
+        @media all and (max-width: @breakpoint-medium) {
+            .cookie-consent__text {
+                font-size: 1rem;
+            }
+
+            .cookie-consent__button {
+                font-size: 1rem;
+            }
+        }
+
+        @media all and (max-width: @breakpoint-mobile) {
+            width: 100%;
+            height: 7rem;
+            bottom: 0;
+            left: 0;
+            padding: 1rem;
+
+            &:before, &:after {
+                display: none;
+            }
+
+            .cookie-consent__text {
+                width: 50%;
+                font-size: 0.8rem;
+                margin-right: 0.25rem;
+                margin-left: 0.25rem;
+            }
+
+            .cookie-consent__button-container {
+                display: flex;
+                flex-direction: column-reverse;
+                width: 30%;
+                height: 100%;
+                margin-right: auto;
+                margin-left: auto;
+            }
+
+            .cookie-consent__button {
+                margin: auto;
+                line-height: 1;
+            }
+        }
+    }
 }
 
 .company-lives {

--- a/static/less/styles.less
+++ b/static/less/styles.less
@@ -1141,7 +1141,7 @@ h1 {
         }
     }
 
-    .cookie-consent {
+    .cookie-notice {
         .ribbon;
         display: flex;
         position: fixed;
@@ -1157,7 +1157,7 @@ h1 {
             color: white;
         }
 
-        .cookie-consent__text {
+        .cookie-notice__text {
             width: 60%;
             margin: auto;
 
@@ -1168,7 +1168,7 @@ h1 {
             line-height: 1.5;
         }
 
-        .cookie-consent__more-info {
+        .cookie-notice__more-info {
             display: inline;
 
             &:hover {
@@ -1176,11 +1176,11 @@ h1 {
             }
         }
 
-        .cookie-consent__button-container {
+        .cookie-notice__button-container {
             margin: auto;
         }
 
-        .cookie-consent__button {
+        .cookie-notice__button {
             margin-left: 0.5rem;
             margin-right: 0.5rem;
             border: none;
@@ -1192,11 +1192,11 @@ h1 {
         }
 
         @media all and (max-width: @breakpoint-medium) {
-            .cookie-consent__text {
+            .cookie-notice__text {
                 font-size: 1rem;
             }
 
-            .cookie-consent__button {
+            .cookie-notice__button {
                 font-size: 1rem;
             }
         }
@@ -1212,14 +1212,14 @@ h1 {
                 display: none;
             }
 
-            .cookie-consent__text {
+            .cookie-notice__text {
                 width: 50%;
                 font-size: 0.8rem;
                 margin-right: 0.25rem;
                 margin-left: 0.25rem;
             }
 
-            .cookie-consent__button-container {
+            .cookie-notice__button-container {
                 display: flex;
                 flex-direction: column-reverse;
                 width: 30%;
@@ -1228,7 +1228,7 @@ h1 {
                 margin-left: auto;
             }
 
-            .cookie-consent__button {
+            .cookie-notice__button {
                 margin: auto;
                 line-height: 1;
             }

--- a/templates/base.html
+++ b/templates/base.html
@@ -9,7 +9,7 @@
     <!--[if lt IE 9]>
         <script src="{% static 'js/modernizr.js' %}"></script>
     <![endif]-->
-    {% if request.get_host == "www.52-lives.org" %}
+    {% if request.get_host == "www.52-lives.org" and request.COOKIES.cookies_accepted == 'true' %}
         <script>
             (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
             (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
@@ -41,7 +41,7 @@
           {% block content %}
           {% endblock content %}
 
-          {% include "includes/footer.html" only %}
+          {% include "includes/footer.html" with request=request only %}
 
       </main>
 
@@ -51,6 +51,7 @@
       {% endblock endpage %}
 
       <script src="{% static 'js/mobile_menu.js' %}"></script>
+      <script src="{% static 'js/cookies.js' %}"></script>
 
       {% if debug %}
           <script src="//localhost:35729/livereload.js"></script>

--- a/templates/base.html
+++ b/templates/base.html
@@ -4,7 +4,7 @@
     <title>{% block title %}52 Lives{% endblock %}</title>
     <link href='//fonts.googleapis.com/css?family=Lato:300,400' rel='stylesheet' type='text/css'>
     <link href="{% static 'css/styles.min.css' %}" rel="stylesheet" />
-    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0, minimum-scale=1">
     <meta name="google-site-verification" content="5x3PoAAz0bcv_CkqNz7347TlbRWMzpRycBH_ABuFaHM" />
     <!--[if lt IE 9]>
         <script src="{% static 'js/modernizr.js' %}"></script>

--- a/templates/includes/footer.html
+++ b/templates/includes/footer.html
@@ -36,4 +36,17 @@
       <p>Anonymity: In most cases we use real names, but occasionally may change someone's name for privacy or safety reasons.</p>
       <p>All rights reserved. <a href="/terms/">Terms</a> &amp; <a href="/privacy/">Privacy</a>. <a href="/cookie-policy/">Cookie Policy</a></p>
   </div>
+
+  <div class="cookie-consent">
+    <p class="cookie-consent__text">
+      We use cookies to ensure that you have the best experience on our website.
+      By clicking "I agree" you give us permission to store cookies in your browser.
+      <a class="cookie-consent__more-info" href="/cookie-policy/">Find out more.</a>
+    </p>
+
+    <div class="cookie-consent__button-container">
+      <button class="cookie-consent__button">I do not agree</button>
+      <button class="cookie-consent__button">I agree</button>
+    </div>
+  </div>
 </footer>

--- a/templates/includes/footer.html
+++ b/templates/includes/footer.html
@@ -37,16 +37,17 @@
       <p>All rights reserved. <a href="/terms/">Terms</a> &amp; <a href="/privacy/">Privacy</a>. <a href="/cookie-policy/">Cookie Policy</a></p>
   </div>
 
-  <div class="cookie-consent">
-    <p class="cookie-consent__text">
-      We use cookies to ensure that you have the best experience on our website.
-      By clicking "I agree" you give us permission to store cookies in your browser.
-      <a class="cookie-consent__more-info" href="/cookie-policy/">Find out more.</a>
-    </p>
+  {% if not 'cookies_accepted' in request.COOKIES %}
+    <div class="cookie-notice">
+      <p class="cookie-notice__text">
+        We use cookies to ensure that you have the best experience on our website.
+        By clicking "I agree" you give us permission to store cookies in your browser.
+        <a class="cookie-notice__more-info" href="/cookie-policy/">Find out more.</a>
+      </p>
 
-    <div class="cookie-consent__button-container">
-      <button class="cookie-consent__button">I do not agree</button>
-      <button class="cookie-consent__button">I agree</button>
+      <div class="cookie-notice__button-container">
+        <button class="cookie-notice__button cookie-notice__button_no">I do not agree</button>
+        <button class="cookie-notice__button cookie-notice__button_yes">I agree</button>
+      </div>
     </div>
-  </div>
-</footer>
+  {% endif %}


### PR DESCRIPTION
This adds a cookie consent banner and cookie logic - we're only really setting one cookie - google analytics. The logic is taken adapted from the final version of the [achurchnearyou](https://github.com/developersociety/achurchnearyou) cookie logic - with simplifications, because there was no requirement here to treat authenticated cookies separately.

https://favro.com/organization/b03d6d6d9b11b61167ac4246/30e671746b81b504ef983ee8?card=Dev-8555