### PR TITLE
Remove title from support form

### DIFF
--- a/apps/lives/admin.py
+++ b/apps/lives/admin.py
@@ -25,7 +25,7 @@ class PersonInline(admin.TabularInline):
     min_num = 0
     show_change_link = True
     readonly_fields = (
-        'title', 'first_name', 'last_name', 'email', 'home_phone', 'mobile_phone', 'reason',
+        'first_name', 'last_name', 'email', 'home_phone', 'mobile_phone', 'reason',
         'message', 'hear_about_us',
     )
 
@@ -49,7 +49,7 @@ class LiveAdmin(admin.ModelAdmin):
         (
             'Live', {
                 'fields': (
-                    'nominee', 'title', 'first_name', 'last_name', 'number',
+                    'nominee', 'first_name', 'last_name', 'number',
                     'image', 'is_published',
                 )
             }
@@ -147,4 +147,3 @@ block_admin.site.register_block(LiveBlock, 'Advanced')
 
 block_admin.site.register(LatestLivesBlock)
 block_admin.site.register_block(LatestLivesBlock, 'Advanced')
-

--- a/apps/people/admin.py
+++ b/apps/people/admin.py
@@ -27,7 +27,7 @@ class PersonAdmin(admin.ModelAdmin):
         'home_phone', 'mobile_phone',
     )
     list_display = (
-        'first_name', 'last_name', 'reason', 'life', 'title', 'email', 'home_phone',
+        'first_name', 'last_name', 'reason', 'life', 'email', 'home_phone',
         'mobile_phone', 'hear_about_us', 'updated_at', 'created_at',
     )
     list_filter = ('reason',)
@@ -35,7 +35,7 @@ class PersonAdmin(admin.ModelAdmin):
         (
             'Person', {
                 'fields': (
-                    'title', 'first_name', 'last_name', 'life', 'reason', 'message',
+                    'first_name', 'last_name', 'life', 'reason', 'message',
                     'hear_about_us',
                 )
             }
@@ -141,7 +141,7 @@ class NominatorAdmin(PersonAdmin):
         (
             'Person', {
                 'fields': (
-                    'title', 'first_name', 'last_name', 'life', 'message',
+                    'first_name', 'last_name', 'life', 'message',
                     'hear_about_us', 'is_agreed',
                 )
             }

--- a/apps/people/forms.py
+++ b/apps/people/forms.py
@@ -84,7 +84,6 @@ class SupportForm(forms.ModelForm):
     class Meta:
         model = Person
         fields = (
-            'title',
             'first_name',
             'last_name',
             'email',

--- a/apps/people/migrations/0012_remove_person_title.py
+++ b/apps/people/migrations/0012_remove_person_title.py
@@ -1,0 +1,18 @@
+# -*- coding: utf-8 -*-
+from __future__ import unicode_literals
+
+from django.db import migrations, models
+
+
+class Migration(migrations.Migration):
+
+    dependencies = [
+        ('people', '0011_change_is_agreed_text'),
+    ]
+
+    operations = [
+        migrations.RemoveField(
+            model_name='person',
+            name='title',
+        ),
+    ]

--- a/apps/people/models.py
+++ b/apps/people/models.py
@@ -16,7 +16,6 @@ from .managers import NominatorManager
 @python_2_unicode_compatible
 class Person(models.Model):
     life = models.ForeignKey(Life, blank=True, null=True)
-    title = models.CharField(max_length=10, choices=live_choices.SOCIAL_TITLE_CHOICES, blank=True)
     first_name = models.CharField(max_length=20)
     last_name = models.CharField(max_length=30)
     email = models.EmailField(blank=True)
@@ -36,7 +35,7 @@ class Person(models.Model):
         return u'{} {}'.format(self.first_name, self.last_name)
 
     def get_full_name(self):
-        return u'{} {} {}'.format(self.title, self.first_name, self.last_name)
+        return u'{} {}'.format(self.first_name, self.last_name)
 
 
 class Nominator(Person):


### PR DESCRIPTION
The partner agreed that we can just remove the title field from this form: https://www.52-lives.org/lives/176/ so this PR removes the title field - this was the only form where it was still being used, I've removed it from the form and from the underlying models too.