### PR TITLE
Sort countries in dropdown

### DIFF
--- a/apps/countries/admin.py
+++ b/apps/countries/admin.py
@@ -18,7 +18,7 @@ class CountryAdmin(admin.ModelAdmin):
         (
             'Country', {
                 'fields': (
-                    'name', 'iso_3166_1_a2',
+                    'name', 'iso_3166_1_a2', 'frequently_used'
                 )
             }
         ),
@@ -33,5 +33,3 @@ class CountryAdmin(admin.ModelAdmin):
     )
 
     readonly_fields = ('id',)
-
-

--- a/apps/countries/help_text.py
+++ b/apps/countries/help_text.py
@@ -3,6 +3,7 @@
 COUNTRY = {
     'iso_3166_1_a2': 'http://en.wikipedia.org/wiki/ISO_3166-1#Current_codes',
     'name': "The commonly used name; e.g. 'United Kingdom'",
-    'display_order': 'Higher the number, higher the country in the list.'
+    'display_order': 'Higher the number, higher the country in the list.',
+    'frequently_used': ('Tick this box if you want the country to display at the top of the list '
+                        'of available countries.')
 }
-

--- a/apps/countries/migrations/0003_and_frequently_used_to_country.py
+++ b/apps/countries/migrations/0003_and_frequently_used_to_country.py
@@ -1,0 +1,19 @@
+# -*- coding: utf-8 -*-
+from __future__ import unicode_literals
+
+from django.db import migrations, models
+
+
+class Migration(migrations.Migration):
+
+    dependencies = [
+        ('countries', '0002_auto_20150625_1118'),
+    ]
+
+    operations = [
+        migrations.AddField(
+            model_name='country',
+            name='frequently_used',
+            field=models.BooleanField(default=False, help_text=b'Tick this box if you want the country to display at the top of the list of available countries.'),
+        ),
+    ]

--- a/apps/countries/models.py
+++ b/apps/countries/models.py
@@ -43,9 +43,13 @@ class Country(models.Model):
         help_text=help_text.COUNTRY['display_order']
     )
 
+    frequently_used = models.BooleanField(
+        default=False,
+        help_text=help_text.COUNTRY['frequently_used']
+    )
+
     class Meta:
         verbose_name_plural = 'Countries'
 
     def __str__(self):
         return self.name
-

--- a/apps/people/forms.py
+++ b/apps/people/forms.py
@@ -9,6 +9,7 @@ from captcha.fields import ReCaptchaField
 from . import choices as persons_choices
 from .models import Person, Nominee
 from .help_texts import PERSON_HELP_TEXTS
+from countries.models import Country
 
 
 class NominateForm(forms.ModelForm):
@@ -65,7 +66,8 @@ class NomineeForm(forms.ModelForm):
         self.fields['relation'].required = True
         self.fields['why_help'].required = True
         self.fields['what_need'].required = True
-
+        
+        self.fields['country'].queryset = Country.objects.order_by('-frequently_used', 'name')
 
 NominatorFormSet = inlineformset_factory(
     Person,

--- a/static/js/country_list.js
+++ b/static/js/country_list.js
@@ -1,14 +1,15 @@
 var country_select = document.getElementById('id_nominee_set-0-country');
 
 if (country_select) {
-    // Create a new option to be added after the frequently selected countries
-    var option_separator = document.createElement("option");
-    option_separator.text = "---------";
-
     // Find the index of the last frequently used country (this is a hack - see function below)
     last_frequently_used_country = find_first_alphabetical_name(country_select);
 
-    country_select.add(option_separator, country_select[last_frequently_used_country])
+    // Add option separator but only when any frequently selected countries have been found
+    if (last_frequently_used_country != 1) {
+        var option_separator = document.createElement("option");
+        option_separator.text = "---------";
+        country_select.add(option_separator, country_select[last_frequently_used_country])
+    }
 }
 
 /**

--- a/static/js/country_list.js
+++ b/static/js/country_list.js
@@ -1,0 +1,44 @@
+var country_select = document.getElementById('id_nominee_set-0-country');
+
+if (country_select) {
+    // Create a new option to be added after the frequently selected countries
+    var option_separator = document.createElement("option");
+    option_separator.text = "---------";
+
+    // Find the index of the last frequently used country (this is a hack - see function below)
+    last_frequently_used_country = find_first_alphabetical_name(country_select);
+
+    country_select.add(option_separator, country_select[last_frequently_used_country])
+}
+
+/**
+ * Find the index of the last option before several alphabetically-ordered options
+ * 
+ * This is a bit of a hack to find the index of the last of the frequently-used
+ * options. It relies on the (probable) assumptions that:
+ *   - there won't be 5 frequently-used country names beginning with 'A'
+ *   - the last of the frequently-used country names will not be one beginning
+ *     with 'A'
+ * This function finds the first five options that begin with 'A' and returns
+ * the index of the option immediately before the first of those five.
+ * 
+ * @param {HTMLElement} country_select 
+ */
+function find_first_alphabetical_name(country_select) {
+    var number_of_countries_to_count = 5;
+
+    var count_of_alphabetical_countries = 0;
+    var i = 0;
+    do {
+        var option = country_select[i];
+        if (option.tagName != 'OPTION') { continue }
+        if (option.text.substring(0, 1) === 'A') { 
+            count_of_alphabetical_countries += 1;
+        } else {
+            count_of_alphabetical_countries = 0;
+        }
+        i++;
+    } while (count_of_alphabetical_countries < number_of_countries_to_count)
+
+    return i - number_of_countries_to_count;
+}

--- a/templates/base.html
+++ b/templates/base.html
@@ -52,6 +52,7 @@
 
       <script src="{% static 'js/mobile_menu.js' %}"></script>
       <script src="{% static 'js/cookies.js' %}"></script>
+      <script src="{% static 'js/country_list.js' %}"></script>
 
       {% if debug %}
           <script src="//localhost:35729/livereload.js"></script>


### PR DESCRIPTION
The partner requested that we clean up the list of countries in the countries select on `NominateForm`  - https://www.52-lives.org/nominate/. Specifically, the partner wanted "United Kingdom" to show up on top.

The list is now sorted alphabetically and I've added a new checkbox "frequently used" to use it for sorting the list too. Then, the javascript adds a separator between the frequently used countries and the rest... though this is somewhat hackish - should work though!

To test, first go to countries in admin and set "frequently used" for some to be true.