### PR TITLE
Add mailchimp script

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,0 +1,13 @@
+### Sources
+Include links to cards and Sentry errors here.
+
+### Description
+What's happening in this PR?
+
+### Setup instructions
+Include any environment variables etc. that are needed to test your code.
+
+### How to test
+Include a summary of the best way a reviewer can test your code. You don't have to be comprehensive, but give the reviewer an idea of where to start.
+
+For comprehensive guidelines on code review at DEV, see here: https://www.notion.so/developersociety/Code-Review-b6d646b1d6e54011ada8169aee543231.

--- a/templates/base.html
+++ b/templates/base.html
@@ -9,6 +9,10 @@
     <!--[if lt IE 9]>
         <script src="{% static 'js/modernizr.js' %}"></script>
     <![endif]-->
+
+    {# Mailchimp pop-up #}
+    <script id="mcjs">!function(c,h,i,m,p){m=c.createElement(h),p=c.getElementsByTagName(h)[0],m.async=1,m.src=i,p.parentNode.insertBefore(m,p)}(document,"script","https://chimpstatic.com/mcjs-connected/js/users/d5cb8c2b7921f5080b59e12f3/813320dcc0d3c6b2271ecaa36.js");</script>
+
     {% if request.get_host == "www.52-lives.org" and request.COOKIES.cookies_accepted == 'true' %}
         <script>
             (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){


### PR DESCRIPTION
### Sources
https://app.forecast.it/T3466

### Description
The partner requested that we add this script into the `<head>`. This PR obliges. 

### Setup instructions
Old project - if you do want to set it up, please follow instructions from https://www.notion.so/developersociety/DEV-s-common-commands-9aadfe0ee8754fe58806630228f108e8 under "Projects without Makefile"

### How to test
Actually, if you just hit approve, that'll do - we won't be able to fully test this locally anyway. The best we can do for testing is to make sure that the script runs - it seems to add a script tag with the .js file mentioned in the script tag that we're adding. Then... there's a 403 from that script in the console, unsurprisingly as I bet it's only allowed to run on their domain. We just need to merge and get back to the partner to see if they got the results they were looking for.

For comprehensive guidelines on code review at DEV, see here: https://www.notion.so/developersociety/Code-Review-b6d646b1d6e54011ada8169aee543231.
