### PR TITLE
Lives grid

### DIFF
--- a/static/js/base.js
+++ b/static/js/base.js
@@ -1,0 +1,6 @@
+var elem = document.querySelector('.lives-grid');
+var pckry = new Packery( elem, {
+  // options
+  itemSelector: '.lifeblock',
+  gutter: 0
+});

--- a/static/less/styles.less
+++ b/static/less/styles.less
@@ -568,47 +568,54 @@ h2, h3 {
 
 .lives {
     display: block;
-    clear: both;
-    padding-bottom: 1em;
-    overflow: hidden;
-
+    margin-top: 10rem;
     .lives-grid {
         margin: 0;
         padding: 0;
-        display: block;
-        clear: both;
+        background: @heading;
     }
+    h2 {
+        font-weight: bold;
+        margin-left: 30rem;
+        display: flex;
+        img {
+            width: 3rem;
+            height: auto;
+            margin-right: 1rem;
+        }
+        &:before {
+            content:none;
+        }
+    }
+ 
     li {
-        display: block;
-        float: left;
-        width: 25%;
-        width: -webkit-calc( 1/4 * 100% );
-        width: calc( 1/4 * 100% );
+        display: inline-block;
+        height: 9rem;
+        width: 9rem;
         position: relative;
         background: @heading;
-        @media all and (min-width: 960px) {
-            width: 20%;
-            width: -webkit-calc( 1/5 * 100% );
-            width: calc( 1/5 * 100% );
-        }
         @media all and (max-width: 840px) {
-            width: 100/3%;
-            width: -webkit-calc( 1/3 * 100% );
-            width: calc( 1/3 * 100% );
+            width: 50%;
+            height: auto; 
         }
 
-        h1 {
+        &:first-of-type
+        {
+            margin-top: -10rem;
+        }
+
+        h3 {
             position: absolute;
             .bold;
             margin: 0;
-            font-size: 125/20em;
+            font-size: 2.5rem;
             top: 50%;
             left: 0;
             right: 0;
             text-align: center;
             transform: translateY(-50%);
+            color: white;
             transition: all 0.3s ease-in-out;
-            @media all and (max-width:640px) { font-size: 2.5em; }
         }
 
         &:before {
@@ -624,6 +631,34 @@ h2, h3 {
             &:before {
                 background: fadeout(@green, 20%);
                 transition: all 0.15s ease-in-out;
+            }
+        }
+        &.large { 
+            width: 27rem;
+            height: 27rem;
+            h3 {
+                font-size: 9.375rem;
+            }
+            @media all and (max-width: 840px) {
+                width: 50%;
+                height: auto; 
+                h3{
+                    font-size: 2.5rem;
+                }
+            }
+        }
+        &.medium {
+            width: 18rem;
+            height: 18rem;
+            h3 {
+                font-size: 6.25rem;
+            }
+            @media all and (max-width: 840px) {
+                width: 50%;
+                height: auto; 
+                h3{
+                    font-size: 2.5rem;
+                }
             }
         }
     }
@@ -653,7 +688,8 @@ h2, h3 {
         bottom: -1em;
         left: 0;
         right: 0;
-        font-size: 1.3em;
+        font-size: 1.3rem;
+        text-align: center;
         &:before, &:after { opacity: 0; transition: all 0.3s ease-in-out; }
         &:before {  margin-left: -10/20em; }
         &:after {  margin-right: -10/20em; }
@@ -668,10 +704,10 @@ h2, h3 {
         text-decoration: none;
 
         &:hover {
-            h1, p, .ribbon {
+            h3, p, .ribbon {
                 transition: all 0.15s ease-in-out;
             }
-            h1 {
+            h3 {
                 font-size: 53/20em;
                 top: 15%;
                 margin-bottom: 25px;

--- a/static/less/styles.less
+++ b/static/less/styles.less
@@ -568,11 +568,16 @@ h2, h3 {
 
 .lives {
     display: block;
-    margin-top: 10rem;
+    margin-top: 9rem;
     .lives-grid {
         margin: 0;
         padding: 0;
         background: @heading;
+         h3{
+            &:before {
+                content: none;
+            }
+        }
     }
     h2 {
         font-weight: bold;
@@ -586,6 +591,10 @@ h2, h3 {
         &:before {
             content:none;
         }
+        @media all and (max-width: 840px) {
+            margin-left: calc(50% + 1rem);
+        }
+
     }
  
     li {
@@ -601,7 +610,7 @@ h2, h3 {
 
         &:first-of-type
         {
-            margin-top: -10rem;
+            margin-top: -9rem;
         }
 
         h3 {

--- a/static/less/styles.less
+++ b/static/less/styles.less
@@ -587,9 +587,10 @@ h2, h3 {
             width: 3rem;
             height: auto;
             margin-right: 1rem;
+            margin-left: 0.5rem;
         }
         &:before {
-            content:none;
+            content: none;
         }
         @media all and (max-width: 840px) {
             margin-left: calc(50% + 1rem);
@@ -631,7 +632,8 @@ h2, h3 {
             content: '';
             position: absolute;
             top: 0; left: 0; right: 0; bottom: 0;
-            background: rgba(0,0,0,.35);
+            background: @heading;
+            opacity: 35%;
             z-index: 1;
             transition: all 0.3s ease-in-out;
         }

--- a/templates/base.html
+++ b/templates/base.html
@@ -63,12 +63,13 @@
 
       {% block endpage %}
       {% endblock endpage %}
-
+      <script src="{% static 'js/libs/packery/packery.js' %}"></script>
+      <script src="{% static 'js/base.js' %}"></script>
       <script src="{% static 'js/mobile_menu.js' %}"></script>
       <script src="{% static 'js/cookies.js' %}"></script>
       <script src="{% static 'js/country_list.js' %}"></script>
       <script src="{% static 'js/form_error.js' %}"></script>
-      
+
       <!-- Google Tag Manager (noscript) -->
       <noscript><iframe src="https://www.googletagmanager.com/ns.html?id=GTM-N9CGXSJ" height="0" width="0" style="display:none;visibility:hidden"></iframe></noscript>
       <!-- End Google Tag Manager (noscript) -->

--- a/templates/blanc_pages/blocks/latestlivesblock.html
+++ b/templates/blanc_pages/blocks/latestlivesblock.html
@@ -1,17 +1,18 @@
-{% load lives_tags thumbnail %}
+{% load lives_tags thumbnail static %}
 
-{% get_latest_lives 10 as latest_lives %}
+{% get_latest_lives object.number_of_lives as latest_lives %}
 
 {% if latest_lives %}
     <div class="{{ css_classes }} lives">
-        <ul class="lives-grid">
+        <h2> <img src="{% static 'img/heart.svg' %}" >Recent lives changed</h2>
+        <ul class="lives-grid grid">
             {% for life in latest_lives %}
-                <li class="lifeblock">
+                <li class="lifeblock grid-item {% if forloop.counter <= 3 %} large {% elif forloop.counter > 3 and forloop.counter < 7 %} medium {% else %} small{% endif %} ">
                     {% thumbnail life.image "280x280" crop="center" as thumb %}
                         <img src="{{ thumb.url }}" width="{{ thumb.width }}" height="{{ thumb.height }}" alt="{{ post.title }}">
                     {% endthumbnail %}
                     <a href="{{ life.get_absolute_url }}">
-                        <h1>#{{ life.number }}</h1>
+                        <h3>#{{ life.number }}</h3>
                         <p>{{ life }}</p>
                         <small class="ribbon">Read more</small>
                     </a>


### PR DESCRIPTION
### Sources
https://app.forecast.it/project/P-181/scoping/T8981
Design https://share.goabstract.com/6071d643-9dac-4969-a634-7d591656f3ea?collectionLayerId=07e44b42-3a58-43bb-b40c-b3897faea702&mode=build 

### Description
Adds masonry styling to the lives grid. Paul specified that this does not need to match the design exactly if another option is easier. I've gone with having the first card rising above on the far left as moving this to the second position was proving too difficult. 

### Setup instructions
Follow instructions for setting up a project with no makefile here https://www.notion.so/developersociety/DEV-s-common-commands-2e54fc09f70a493484bfd93d9c678e28 except when running mkproject you'll need to specify python2.7 
`mkproject -f --python=python2.7 52lives`


### How to test
Check that the grid mostly matches the design and looks ok in different screen sizes. 

For comprehensive guidelines on code review at DEV, see here: https://www.notion.so/developersociety/Code-Review-b6d646b1d6e54011ada8169aee543231.
