### PR TITLE
Video block

### DIFF
--- a/apps/pages/admin.py
+++ b/apps/pages/admin.py
@@ -1,3 +1,13 @@
 from django.contrib import admin
 
 # Register your models here.
+# -*- coding: utf-8 -*-
+
+from blanc_pages import block_admin
+
+from .blocks.models import Video
+
+
+block_admin.site.register(Video)
+block_admin.site.register_block(Video, 'Video')
+

--- a/apps/pages/blocks/models.py
+++ b/apps/pages/blocks/models.py
@@ -1,0 +1,24 @@
+# -*- coding: utf-8 -*-
+
+from django.db import models
+from django.utils.encoding import python_2_unicode_compatible
+
+from blanc_basic_assets.fields import AssetForeignKey
+from blanc_pages.models.blocks import BaseBlock
+from pages import choices as colour_choices
+
+
+@python_2_unicode_compatible
+class Video(BaseBlock):
+    thumbnail_image = AssetForeignKey('assets.Image', blank=True, null=True, on_delete=models.PROTECT)
+    title = models.TextField()
+    video_embed_link = models.URLField(blank=True)
+    colour = models.CharField(blank=True, max_length=40, choices=colour_choices.COLOUR_CHOICES)
+
+
+    class Meta:
+        ordering = ('title',)
+
+    def __str__(self):
+        return 'Video'
+

--- a/apps/pages/blocks/models.py
+++ b/apps/pages/blocks/models.py
@@ -10,7 +10,7 @@ from pages import choices as colour_choices
 
 @python_2_unicode_compatible
 class Video(BaseBlock):
-    thumbnail_image = AssetForeignKey('assets.Image', blank=True, null=True, on_delete=models.PROTECT)
+    thumbnail_image = AssetForeignKey('assets.Image', null=True, on_delete=models.PROTECT)
     title = models.TextField()
     video_embed_link = models.URLField(blank=True)
     colour = models.CharField(blank=True, max_length=40, choices=colour_choices.COLOUR_CHOICES)

--- a/apps/pages/choices.py
+++ b/apps/pages/choices.py
@@ -1,0 +1,8 @@
+# -*- coding: utf-8 -*-
+
+COLOUR_CHOICES = (
+    ('dark_purple', 'Dark Purple'),
+    ('purple', 'Purple'),
+    ('green', 'Green'),
+)
+

--- a/apps/pages/migrations/0001_initial.py
+++ b/apps/pages/migrations/0001_initial.py
@@ -1,0 +1,31 @@
+# -*- coding: utf-8 -*-
+from __future__ import unicode_literals
+
+from django.db import migrations, models
+import django.db.models.deletion
+import blanc_basic_assets.fields
+
+
+class Migration(migrations.Migration):
+
+    dependencies = [
+        ('assets', '__first__'),
+        ('pages', '0004_rename_tables'),
+    ]
+
+    operations = [
+        migrations.CreateModel(
+            name='Video',
+            fields=[
+                ('id', models.AutoField(verbose_name='ID', serialize=False, auto_created=True, primary_key=True)),
+                ('title', models.TextField()),
+                ('video_embed_link', models.URLField(blank=True)),
+                ('colour', models.CharField(blank=True, max_length=40, choices=[(b'dark_purple', b'Dark Purple'), (b'purple', b'Purple'), (b'green', b'Green')])),
+                ('content_block', models.ForeignKey(editable=False, to='pages.ContentBlock', null=True)),
+                ('thumbnail_image', blanc_basic_assets.fields.AssetForeignKey(on_delete=django.db.models.deletion.PROTECT, blank=True, to='assets.Image', null=True)),
+            ],
+            options={
+                'ordering': ('title',),
+            },
+        ),
+    ]

--- a/apps/pages/migrations/0001_initial.py
+++ b/apps/pages/migrations/0001_initial.py
@@ -22,7 +22,7 @@ class Migration(migrations.Migration):
                 ('video_embed_link', models.URLField(blank=True)),
                 ('colour', models.CharField(blank=True, max_length=40, choices=[(b'dark_purple', b'Dark Purple'), (b'purple', b'Purple'), (b'green', b'Green')])),
                 ('content_block', models.ForeignKey(editable=False, to='pages.ContentBlock', null=True)),
-                ('thumbnail_image', blanc_basic_assets.fields.AssetForeignKey(on_delete=django.db.models.deletion.PROTECT, blank=True, to='assets.Image', null=True)),
+                ('thumbnail_image', blanc_basic_assets.fields.AssetForeignKey(on_delete=django.db.models.deletion.PROTECT, to='assets.Image', null=True)),
             ],
             options={
                 'ordering': ('title',),

--- a/apps/pages/models.py
+++ b/apps/pages/models.py
@@ -1,3 +1,4 @@
 from django.db import models
 
 # Create your models here.
+from .blocks.models import Video  # noqa

--- a/static/js/base.js
+++ b/static/js/base.js
@@ -1,0 +1,28 @@
+const video_block = document.querySelectorAll('.blanc_page_blocktype_video');
+const body = document.querySelector('body');
+
+video_block.forEach((block) => {
+
+    const play = block.querySelector('.video__play');
+    const close = block.querySelector('.close');
+    const lightbox = block.querySelector('.lightbox');
+
+    if (lightbox) {
+        const lightbox_append = lightbox.querySelector('.iframe__container');
+
+        // Append video iframe using data attribute
+        play.onclick = (event) => {
+            event.preventDefault();
+            lightbox_append.innerHTML = lightbox_append.dataset.append;
+            lightbox.classList.add('active');
+            body.classList.add('no-scroll');
+        };
+
+        close.onclick = (event) => {
+            event.preventDefault();
+            lightbox.classList.remove('active');
+            lightbox_append.innerHTML = '';
+            body.classList.remove('no-scroll');
+        };
+    }
+});

--- a/static/less/styles.less
+++ b/static/less/styles.less
@@ -1381,6 +1381,16 @@ h2, h3 {
             }
         }
     } 
+    @media all and (max-width: @breakpoint-mobile) {
+        .video-block__background {
+            width: 80%;
+            height: 16rem;
+        }
+        iframe {
+            width: 100%;
+            height: 16rem;
+        }
+    }
 
     figure {
         margin: 0;

--- a/static/less/styles.less
+++ b/static/less/styles.less
@@ -47,6 +47,9 @@ body {
     font-size: 1.25em;
     line-height: 1.5;
     -webkit-font-smoothing: antialiased;
+    &.no-scroll {
+        overflow: hidden;
+    }
 }
 
 a {
@@ -1323,4 +1326,107 @@ h2, h3 {
 
 .blanc-pages-toolbar {
   z-index: 1000;
+}
+
+.blanc_page_blocktype_video {
+    display: flex;
+    justify-content: center;
+    margin: 1rem;
+    .video-block__background {
+        position:relative;
+        max-width: 55rem;
+        width: 70%;
+        height: 30rem;
+
+        .video-block__overlay {
+            height: 100%;
+            opacity: 50%;
+
+            &.dark_purple {
+                background-color: @heading;
+            }
+            &.purple {
+                background-color: @purple; 
+            }
+            &.green {
+                background-color: @green;
+            }
+        }
+
+        .video-block__content {
+            position: absolute;
+            top:0;
+            bottom: 0;
+            left: 0;
+            right: 0;
+            display: flex;
+            flex-flow:column;
+            justify-content: center;
+            align-items: center;
+
+            h2 {
+                color: white;
+                font-weight: bold;
+                &:before{
+                    content: none;
+                }
+            }
+
+            .arrow-icon {
+                height: 1.25rem;
+                width: 2rem;
+                transform: rotate(270deg);
+                margin-left: 0.5rem;
+                margin-top: 0.3rem;
+            }
+        }
+    } 
+
+    figure {
+        margin: 0;
+    }
+
+    .lightbox {
+        display: none;
+        position: fixed;
+        top: 0;
+        bottom: 0;
+        left: 0;
+        right: 0;
+        z-index: 10000;
+        align-items: center;
+        justify-content: center;
+        padding: 2rem 1rem;
+        background: @heading;
+        opacity: 90%;
+
+        &.active {
+            display: flex;
+        }
+
+        .close {
+            position: absolute;
+            display: inline-flex;
+            align-items: center;
+            right: 5rem;
+            top: 5rem;
+            font-size: 2rem;
+            font-weight: 700;
+            color: white;
+            text-transform: uppercase;
+            cursor: pointer;
+
+            .icon {
+                margin-left: 0.75rem;
+            }
+        }
+
+        .iframe__container {
+            width: 100%;
+            height: 100%;
+            display: flex;
+            align-items: center;
+            justify-content: center;
+        }
+    }
 }

--- a/templates/base.html
+++ b/templates/base.html
@@ -64,6 +64,7 @@
       {% block endpage %}
       {% endblock endpage %}
 
+      <script src="{% static 'js/base.js' %}"></script>
       <script src="{% static 'js/mobile_menu.js' %}"></script>
       <script src="{% static 'js/cookies.js' %}"></script>
       <script src="{% static 'js/country_list.js' %}"></script>

--- a/templates/blanc_pages/blocks/video.html
+++ b/templates/blanc_pages/blocks/video.html
@@ -1,0 +1,19 @@
+{% load static %}
+<div class="{{css_classes }}">
+    <div class="video-block__background" style="background: url({{object.thumbnail_image.file.url}}) center center/cover no-repeat" >
+      <div class="video-block__overlay  {{object.colour}}"></div>
+
+        <div class="video-block__content ">
+            <h2>{{object.title}}</h2>
+            <button class="ribbon video__play">Watch             <img class="arrow-icon" src="{% static 'img/heart_white.svg' %}" ></button>
+        </div>
+    </div>
+    <div class="lightbox">
+        <div class="close">
+        X
+        </div>
+        <figure class="iframe__container" data-append='<iframe class ="video"width="80%"height="60%"src="{{object.video_embed_link}}"frameborder="0"allow="accelerometer; autoplay; encrypted-media; gyroscope; picture-in-picture"allowfullscreen></iframe>'  >
+    
+        </figure>
+    </div>
+</div>

--- a/templates/blanc_pages/blocks/video.html
+++ b/templates/blanc_pages/blocks/video.html
@@ -13,7 +13,7 @@
             <div class="close">
             X
             </div>
-            <figure class="iframe__container" data-append='<iframe class ="video"width="80%"height="60%"src="{{object.video_embed_link}}"frameborder="0"allow="accelerometer; autoplay; encrypted-media; gyroscope; picture-in-picture"allowfullscreen></iframe>'  >
+            <figure class="iframe__container" data-append='<iframe class ="video"width="60%"height="60%"src="{{object.video_embed_link}}"frameborder="0"allow="accelerometer; autoplay; encrypted-media; gyroscope; picture-in-picture"allowfullscreen></iframe>'  >
         
             </figure>
         </div>

--- a/templates/blanc_pages/blocks/video.html
+++ b/templates/blanc_pages/blocks/video.html
@@ -1,19 +1,21 @@
 {% load static %}
-<div class="{{css_classes }}">
-    <div class="video-block__background" style="background: url({{object.thumbnail_image.file.url}}) center center/cover no-repeat" >
-      <div class="video-block__overlay  {{object.colour}}"></div>
+{% if object.video_embed_link %}
+    <div class="{{css_classes }}">
+        <div class="video-block__background" style="background: url({{object.thumbnail_image.file.url}}) center center/cover no-repeat" >
+        <div class="video-block__overlay  {{object.colour}}"></div>
 
-        <div class="video-block__content ">
-            <h2>{{object.title}}</h2>
-            <button class="ribbon video__play">Watch             <img class="arrow-icon" src="{% static 'img/heart_white.svg' %}" ></button>
+            <div class="video-block__content ">
+                <h2>{{object.title}}</h2>
+                <button class="ribbon video__play">Watch             <img class="arrow-icon" src="{% static 'img/heart_white.svg' %}" ></button>
+            </div>
+        </div>
+        <div class="lightbox">
+            <div class="close">
+            X
+            </div>
+            <figure class="iframe__container" data-append='<iframe class ="video"width="80%"height="60%"src="{{object.video_embed_link}}"frameborder="0"allow="accelerometer; autoplay; encrypted-media; gyroscope; picture-in-picture"allowfullscreen></iframe>'  >
+        
+            </figure>
         </div>
     </div>
-    <div class="lightbox">
-        <div class="close">
-        X
-        </div>
-        <figure class="iframe__container" data-append='<iframe class ="video"width="80%"height="60%"src="{{object.video_embed_link}}"frameborder="0"allow="accelerometer; autoplay; encrypted-media; gyroscope; picture-in-picture"allowfullscreen></iframe>'  >
-    
-        </figure>
-    </div>
-</div>
+{% endif %}


### PR DESCRIPTION
### Sources
https://app.forecast.it/project/P-181/workflow/T8979

### Description
Adds a video block which includes an embed url, overlay/ thumbnail image, Title and colour options.

### Setup instructions

To get this project running locally, you need to create an empty file at ~/.pip/pip.conf if you don't have that file already (create the .pip directory too), and add into it:
```
[global]
extra-index-url=https://pypackages:lL0G5jW7MQjq7dLiCWg2wwz8I2entqnS@pypackages.blanctools.com/
```
Then once you've cloned the project (with dev-clone 52lives), to set it up follow the instructions here for projects without a Makefile:
https://www.notion.so/developersociety/DEV-s-common-commands-2e54fc09f70a493484bfd93d9c678e28
However when running mkproject you need to specify Python 2.7, so run:
`mkproject -f --python=python2.7 52lives`

### How to test
Add a video block and check that this matches the design (top video on design) the two column section will be in a following PR. 

For comprehensive guidelines on code review at DEV, see here: https://www.notion.so/developersociety/Code-Review-b6d646b1d6e54011ada8169aee543231.
