### PR TITLE
Two column video block

### DIFF
--- a/apps/pages/admin.py
+++ b/apps/pages/admin.py
@@ -5,9 +5,11 @@ from django.contrib import admin
 
 from blanc_pages import block_admin
 
-from .blocks.models import Video
+from .blocks.models import Video, TwoColumnBlock
 
 
 block_admin.site.register(Video)
 block_admin.site.register_block(Video, 'Video')
 
+block_admin.site.register(TwoColumnBlock)
+block_admin.site.register_block(TwoColumnBlock, 'Two Colummn Block')

--- a/apps/pages/blocks/models.py
+++ b/apps/pages/blocks/models.py
@@ -5,7 +5,7 @@ from django.utils.encoding import python_2_unicode_compatible
 
 from blanc_basic_assets.fields import AssetForeignKey
 from blanc_pages.models.blocks import BaseBlock
-from pages import choices as colour_choices
+from pages import choices as choices
 
 
 @python_2_unicode_compatible
@@ -13,8 +13,7 @@ class Video(BaseBlock):
     thumbnail_image = AssetForeignKey('assets.Image', null=True, on_delete=models.PROTECT)
     title = models.TextField()
     video_embed_link = models.URLField(blank=True)
-    colour = models.CharField(blank=True, max_length=40, choices=colour_choices.COLOUR_CHOICES)
-
+    colour = models.CharField(blank=True, max_length=40, choices=choices.COLOUR_CHOICES)
 
     class Meta:
         ordering = ('title',)
@@ -22,3 +21,16 @@ class Video(BaseBlock):
     def __str__(self):
         return 'Video'
 
+
+class TwoColumnBlock(BaseBlock):
+    column_one_thumbnail_image = AssetForeignKey('assets.Image', blank=True, null=True, on_delete=models.PROTECT, related_name='first_image')
+    column_one_title = models.TextField()
+    column_one_video_embed_link = models.URLField(blank=True)
+    column_one_colour = models.CharField(blank=True, max_length=40, choices=choices.COLOUR_CHOICES)
+
+    column_two_thumbnail_image = AssetForeignKey('assets.Image', blank=True, null=True, on_delete=models.PROTECT, related_name='second_image')
+    column_two_title = models.TextField()
+    column_two_video_embed_link = models.URLField(blank=True)
+    column_two_colour = models.CharField(blank=True, max_length=40, choices=choices.COLOUR_CHOICES)
+
+    column_ratio = models.CharField(blank=True, max_length=40, choices=choices.COLUMN_CHOICES)

--- a/apps/pages/choices.py
+++ b/apps/pages/choices.py
@@ -6,3 +6,9 @@ COLOUR_CHOICES = (
     ('green', 'Green'),
 )
 
+COLUMN_CHOICES = (
+    ("even", "1:1"),
+    ("stack-right", "1:2"), 
+    ("stack-left", "2:1"),
+)
+

--- a/apps/pages/migrations/0002_twocolumnblock.py
+++ b/apps/pages/migrations/0002_twocolumnblock.py
@@ -1,0 +1,37 @@
+# -*- coding: utf-8 -*-
+from __future__ import unicode_literals
+
+from django.db import migrations, models
+import django.db.models.deletion
+import blanc_basic_assets.fields
+
+
+class Migration(migrations.Migration):
+
+    dependencies = [
+        ('assets', '__first__'),
+        ('pages', '0004_rename_tables'),
+        ('lives52_pages', '0001_initial'),
+    ]
+
+    operations = [
+        migrations.CreateModel(
+            name='TwoColumnBlock',
+            fields=[
+                ('id', models.AutoField(verbose_name='ID', serialize=False, auto_created=True, primary_key=True)),
+                ('column_one_title', models.TextField()),
+                ('column_one_video_embed_link', models.URLField(blank=True)),
+                ('column_one_colour', models.CharField(blank=True, max_length=40, choices=[(b'dark_purple', b'Dark Purple'), (b'purple', b'Purple'), (b'green', b'Green')])),
+                ('column_two_title', models.TextField()),
+                ('column_two_video_embed_link', models.URLField(blank=True)),
+                ('column_two_colour', models.CharField(blank=True, max_length=40, choices=[(b'dark_purple', b'Dark Purple'), (b'purple', b'Purple'), (b'green', b'Green')])),
+                ('column_ratio', models.CharField(blank=True, max_length=40, choices=[(b'even', b'1:1'), (b'stack-right', b'1:2'), (b'stack-left', b'2:1')])),
+                ('column_one_thumbnail_image', blanc_basic_assets.fields.AssetForeignKey(related_name='first_image', on_delete=django.db.models.deletion.PROTECT, blank=True, to='assets.Image', null=True)),
+                ('column_two_thumbnail_image', blanc_basic_assets.fields.AssetForeignKey(related_name='second_image', on_delete=django.db.models.deletion.PROTECT, blank=True, to='assets.Image', null=True)),
+                ('content_block', models.ForeignKey(editable=False, to='pages.ContentBlock', null=True)),
+            ],
+            options={
+                'abstract': False,
+            },
+        ),
+    ]

--- a/apps/pages/models.py
+++ b/apps/pages/models.py
@@ -1,4 +1,5 @@
 from django.db import models
 
 # Create your models here.
-from .blocks.models import Video  # noqa
+from .blocks.models import Video, TwoColumnBlock  # noqa
+

--- a/static/less/styles.less
+++ b/static/less/styles.less
@@ -1340,7 +1340,7 @@ h2, h3 {
 
         .video-block__overlay {
             height: 100%;
-            opacity: 50%;
+            opacity: 80%;
 
             &.dark_purple {
                 background-color: @heading;
@@ -1429,4 +1429,59 @@ h2, h3 {
             justify-content: center;
         }
     }
+}
+
+.blanc_page_blocktype_twocolumnblock {
+    display: flex;
+    max-width: 76.5rem;
+    margin: 0 auto;
+
+    &.stack-right {
+        .blanc_page_blocktype_video:first-of-type {
+            flex: 1.5;
+            .video-block__background {
+                height: 21.5rem;
+                width: 100%;
+            }
+        }
+        .blanc_page_blocktype_video:nth-of-type(2) {
+            .video-block__background {
+                height: 16.5rem;
+                width: 100%;
+            }  
+        }
+    }
+    &.stack-left {
+        .blanc_page_blocktype_video:nth-of-type(2){
+            flex: 1.5;
+            .video-block__background {
+                height: 21.5rem;
+                width: 100%;
+            }
+        }
+        .blanc_page_blocktype_video:first-of-type {
+            .video-block__background {
+                height: 16.5rem;
+                width: 100%;
+            }  
+        }
+    }
+
+    .blanc_page_blocktype_video {
+        flex:1;
+      
+        .video-block__background {
+            width: 90%;
+            height: 20rem;
+        }
+    }
+    @media all and (max-width: @breakpoint-mobile) {
+        display: block;
+        .blanc_page_blocktype_video {
+              .video-block__background {
+                height: 16rem;
+            }
+        }
+    }
+  
 }

--- a/templates/base.html
+++ b/templates/base.html
@@ -63,7 +63,7 @@
 
       {% block endpage %}
       {% endblock endpage %}
-
+      <script src="{% static 'js/base.js' %}"></script>
       <script src="{% static 'js/mobile_menu.js' %}"></script>
       <script src="{% static 'js/cookies.js' %}"></script>
       <script src="{% static 'js/country_list.js' %}"></script>

--- a/templates/blanc_pages/blocks/twocolumnblock.html
+++ b/templates/blanc_pages/blocks/twocolumnblock.html
@@ -1,0 +1,41 @@
+{% load static %}
+{% if object.column_one_video_embed_link %}
+<div class="{{css_classes }} {{ object.column_ratio}}">
+    <div class="blanc_page_blocktype_video">
+    <div class="video-block__background" style="background: url({{object.column_one_thumbnail_image.file.url}}) center center/cover no-repeat" >
+      <div class="video-block__overlay  {{object.column_one_colour}}"></div>
+
+        <div class="video-block__content ">
+            <h2>{{object.column_one_title}}</h2>
+            <button class="ribbon video__play">Watch<img class="arrow-icon" src="{% static 'img/heart_white.svg' %}" ></button>
+        </div>
+    </div>
+    <div class="lightbox">
+        <div class="close">
+        X
+        </div>
+        <figure class="iframe__container" data-append='<iframe class ="video"width="80%"height="60%"src="{{object.column_one_video_embed_link}}"frameborder="0"allow="accelerometer; autoplay; encrypted-media; gyroscope; picture-in-picture"allowfullscreen></iframe>'  >
+        </figure>
+    </div>
+</div>
+{% endif %}
+{% if object.column_two_video_embed_link %}
+<div class="blanc_page_blocktype_video">
+    <div class="video-block__background" style="background: url({{object.column_two_thumbnail_image.file.url}}) center center/cover no-repeat" >
+        <div class="video-block__overlay  {{object.column_two_colour}}"></div>
+  
+          <div class="video-block__content ">
+              <h2>{{object.column_two_title}}</h2>
+              <button class="ribbon video__play">Watch<img class="arrow-icon" src="{% static 'img/heart_white.svg' %}" ></button>
+          </div>
+      </div>
+      <div class="lightbox">
+          <div class="close">
+          X
+          </div>
+          <figure class="iframe__container" data-append='<iframe class ="video"width="80%"height="60%"src="{{object.column_two_video_embed_link}}"frameborder="0"allow="accelerometer; autoplay; encrypted-media; gyroscope; picture-in-picture"allowfullscreen></iframe>'  >
+          </figure>
+      </div>
+    </div>
+</div>
+{% endif %}


### PR DESCRIPTION
### Sources
https://app.forecast.it/T8980

### Description
Adds a two column video block. Ideally this would have been a two column block with a streamfield for multiple blocks but the only other block available would be the banner block and I also couldn't figure out how / if streamfields worked on this project. So the MVP is just the two column video block on the design

### Setup instructions
Create an empty file at ~/.pip/pip.conf if you don't have that file already (create the .pip directory too), and add into it:
```
[global]
extra-index-url=https://pypackages:lL0G5jW7MQjq7dLiCWg2wwz8I2entqnS@pypackages.blanctools.com/
```
Follow the instructions here for projects without a Makefile:
https://www.notion.so/developersociety/DEV-s-common-commands-2e54fc09f70a493484bfd93d9c678e28
However when running mkproject you need to specify Python 2.7, so run:
mkproject -f --python=python2.7 52lives

### How to test
Log in to the admin, go to the homepage and add a two column block in a content section. Check that it looks ok different viewports and with different ratio / colour options

For comprehensive guidelines on code review at DEV, see here: https://www.notion.so/developersociety/Code-Review-b6d646b1d6e54011ada8169aee543231.
