### PR TITLE
Restyle navigation with dropdown

### DIFF
--- a/static/less/styles.less
+++ b/static/less/styles.less
@@ -241,7 +241,7 @@ h2, h3 {
     a {
         color: white;
         text-decoration: none;
-        padding: 0 1.3rem;
+        padding: 0 0.5rem;
         &:hover, &.active { color: @green; }
     }
     li + li {
@@ -261,6 +261,11 @@ h2, h3 {
                 padding: 0.25rem 0 ;
             }
         }   
+    }
+    @media all and (max-width: @breakpoint-medium) {
+        a {
+            padding: 0 0.3rem;
+        }
     }
 }
 

--- a/static/less/styles.less
+++ b/static/less/styles.less
@@ -112,7 +112,7 @@ h2, h3 {
     display: inline-flex;
     font-size: 35/20em;
     line-height: 1.9em;
-    height: 2em;
+    height: 3.5rem;
     margin: 1em 0;
     padding: 0 1em;
     border: none;
@@ -225,29 +225,48 @@ h2, h3 {
 
     ul {
         .ribbon;
+        display: inline-flex;
         margin: 0 auto;
         margin-bottom: -16/20em;
         top: .15em;
     }
+
     li {
         display: inline-block;
         position: relative;
         z-index: 2;
-        padding: 0.5rem;
+        margin-left: 0.2rem;
+        height: auto;  
     }
     a {
         color: white;
         text-decoration: none;
-        &:hover, &.active { color: @purple; }
+        padding: 0 1.3rem;
+        &:hover, &.active { color: @green; }
     }
     li + li {
-        border-left: 2px solid #7cb9a6;
+        a {
+            border-left: 2px solid #7cb9a6;   
+        }
+    }
+    @media all and (max-width: @breakpoint-mobile) {
+        a {
+            &:hover, &.active { color: @heading; }
+        }
+        li + li {
+            padding: 0.25rem 0;
+            a {
+                border-top: 2px solid #7cb9a6;
+                border-left: none;
+                padding: 0.25rem 0 ;
+            }
+        }   
     }
 }
 
 // Responsively change main menu
 .head .nav {
-    font-size: 1em;
+    font-size: 1rem;
 
     @media all and (max-width: @breakpoint-full) {
         font-size: 0.8em;
@@ -281,6 +300,40 @@ h2, h3 {
 
             .nav__link + .nav__link {
                 margin-left: 0;
+            }
+        }
+    }
+
+    .dropdown {
+        display: none;
+    }
+
+    @media all and (min-width: @breakpoint-mobile) {
+        .nav__link:hover {
+            background: @heading;
+            position: relative;
+            a {
+                border-left: none;
+            }
+            .dropdown {
+                display: block;
+                position:absolute;
+                top:100%;
+                height: auto;
+                left:0;
+                right:0;
+                background: @heading;
+                display: flex;
+                flex-flow: column nowrap;
+                font-size: 1rem;
+
+                &:before, &:after {
+                    content: none;
+                }
+                    a {
+                        border-left: none;
+                        padding: 0;
+                    }
             }
         }
     }
@@ -350,33 +403,6 @@ h2, h3 {
 
     .nav__menu-toggle-icon .line-3 {
         transform: rotate(-45deg) translateY(0) translateX(0);
-    }
-}
-
-// Style the submenu
-.head .subnav {
-    font-size: 60%;
-    margin-top: 3em;
-    position: absolute;
-    left: 50%;
-    transform: translateX(-50%);
-}
-
-// Responsively change the submenu
-.head .subnav {
-    @media all and (max-width: @breakpoint-full) {
-        font-size: 0.5em;
-    }
-
-    @media all and (max-width: @breakpoint-medium) {
-        font-size: 0.4em;
-    }
-
-    @media all and (max-width: @breakpoint-mobile) {
-        position: relative;
-        ul {
-            height: auto;
-        }
     }
 }
 
@@ -1134,31 +1160,38 @@ h2, h3 {
     background: @heading;
     color: white;
     font-weight: normal;
+    padding: 1em;
  
     li {
         font-size: 1.5rem;
         line-height: 1.1;
     }
+    a {
+        &:hover, &.active { color: @heading; }
+    }
 
     @media all and (max-width: @breakpoint-medium) {
-
-        .nav__links{
+    
+        .nav__links {
             background: none;
             flex-flow: column wrap;
             height: auto;
             &:before, &:after {
                 display: none;
             }
-            li+li{
-                border-left: none;
-                border-top: 2px solid #7cb9a6;
+            a {
+                &:hover, &.active { color: @green; }
             }
 
+            li+li {
+                padding-top: 1rem;
+
+                a {
+                    border-left: none;
+                    border-top: 2px solid #7cb9a6;
+                }
+            }
         }
-    }
-  
-    @media all and (max-width:960px) {
-        padding: 0 1em;
     }
 
     .legal {

--- a/templates/includes/navigation.html
+++ b/templates/includes/navigation.html
@@ -1,6 +1,6 @@
 {% load blancpages_navigation %}
 
-{% get_root_pages current_page as root_pages %}
+{% get_root_pages as root_pages %}
 {% get_pages_at_level current_page as secondary_pages %}
 
 
@@ -32,21 +32,19 @@
                 <a href="{{ page.get_absolute_url }}"{% if page_active %} class="active"{% endif %}>
                     {{ page.title }}
                 </a>
+                {% get_pages_at_level page as next_level_pages %}
+                {% if next_level_pages %}
+                    <ul class="dropdown">
+                        {% for child_page, page_active in next_level_pages %}
+                            <li>
+                                <a href="{{ child_page.get_absolute_url }}">
+                                    {{ child_page.title }}
+                                </a>
+                            </li>
+                        {% endfor %}
+                    </ul>
+                {% endif %}    
             </li>
         {% endfor %}
     </ul>
 </nav>
-
-{% if secondary_pages %}
-    <nav class="subnav">
-        <ul>
-            {% for page, page_active in secondary_pages %}
-                <li>
-                    <a href="{{ page.get_absolute_url }}"{% if page_active %} class="active"{% endif %}>
-                        {{ page.title }}
-                    </a>
-                </li>
-            {% endfor %}
-        </ul>
-    </nav>
-{% endif %}


### PR DESCRIPTION
### Sources
https://app.forecast.it/T8976
Design - https://share.goabstract.com/6071d643-9dac-4969-a634-7d591656f3ea?collectionLayerId=07e44b42-3a58-43bb-b40c-b3897faea702&mode=design&sha=latest

### Description
Restyles the primary navigation and adds the secondary navigation as a dropdown

### Setup instructions
Create an empty file at ~/.pip/pip.conf if you don't have that file already (create the .pip directory too), and add into it:

```
[global]
extra-index-url=https://pypackages:lL0G5jW7MQjq7dLiCWg2wwz8I2entqnS@pypackages.blanctools.com/
```
Follow the instructions here for projects without a Makefile:
https://www.notion.so/developersociety/DEV-s-common-commands-2e54fc09f70a493484bfd93d9c678e28
However when running mkproject you need to specify Python 2.7, so run:
`mkproject -f --python=python2.7 52lives`

### How to test
check that the navigation looks ok across all viewports and that the dropdown works correctly on desktop

For comprehensive guidelines on code review at DEV, see here: https://www.notion.so/developersociety/Code-Review-b6d646b1d6e54011ada8169aee543231.
